### PR TITLE
More customizable.

### DIFF
--- a/Source/JTSScrollIndicator.h
+++ b/Source/JTSScrollIndicator.h
@@ -42,6 +42,11 @@
  */
 - (void)reset;
 
+/**
+ *  Math method. It will be used when calculate the indicator's frame.
+ */
++ (CGRect)targetRectForScrollView:(UIScrollView *)scrollView;
+
 @end
 
 ///-----------------------------------------------------------

--- a/Source/JTSScrollIndicator.m
+++ b/Source/JTSScrollIndicator.m
@@ -31,6 +31,7 @@ static UIEdgeInsets JTSScrollIndicator_InherentInset;
     self = [super initWithFrame:startingFrame];
     if (self) {
         _scrollView = scrollView;
+        _scrollView.showsVerticalScrollIndicator = NO;  // The default scroll indicator in the scroll view must to be hide to show JTSScrollIndicator.
         self.layer.cornerRadius = JTSScrollIndicator_IndicatorWidth * 0.75;
         self.clipsToBounds = YES;
         self.alpha = 0;

--- a/Source/JTSScrollIndicatorConfig.h
+++ b/Source/JTSScrollIndicatorConfig.h
@@ -1,0 +1,25 @@
+//
+//  JTSScrollIndicatorConfig.h
+//
+//  Created by TAE JUN KIM (korean.darren@gmail.com) on 2015. 8. 26..
+//
+
+#import <UIKit/UIKit.h>
+
+@class JTSScrollIndicator;
+
+@interface JTSScrollIndicatorConfig : NSObject
+
+@property (assign, nonatomic) CGFloat width;
+@property (assign, nonatomic) CGFloat minHeightWhenCompressed;
+@property (assign, nonatomic) CGFloat minHeightWhenScrolling;
+@property (assign, nonatomic) CGFloat rightMargin;
+@property (assign, nonatomic) UIEdgeInsets inherentInsets;
+
+@property (weak, nonatomic) JTSScrollIndicator *indicator;
+
++ (JTSScrollIndicatorConfig *)sharedConfig;
+
+- (instancetype)init;
+
+@end

--- a/Source/JTSScrollIndicatorConfig.m
+++ b/Source/JTSScrollIndicatorConfig.m
@@ -1,0 +1,82 @@
+//
+//  JTSScrollIndicatorConfig.h
+//
+//  Created by TAE JUN KIM (korean.darren@gmail.com) on 2015. 8. 26..
+//
+
+#import "JTSScrollIndicatorConfig.h"
+#import "JTSScrollIndicator.h"
+
+static CGFloat JTSScrollIndicator_IndicatorWidth = 2.5f;
+static CGFloat JTSScrollIndicator_MinIndicatorHeightWhenCompressed = 8.0f;
+static CGFloat JTSScrollIndicator_MinIndicatorHeightWhenScrolling = 37.0f;
+static CGFloat JTSScrollIndicator_IndicatorRightMargin = 2.5f;
+static UIEdgeInsets JTSScrollIndicator_InherentInset;
+
+@implementation JTSScrollIndicatorConfig
+
++ (JTSScrollIndicatorConfig *)sharedConfig
+{
+    static JTSScrollIndicatorConfig *sharedInstance = nil;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[JTSScrollIndicatorConfig alloc] init];
+    });
+    
+    return sharedInstance;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        JTSScrollIndicator_InherentInset = UIEdgeInsetsMake(2.5, 0, 2.5, 0);
+        _width = JTSScrollIndicator_IndicatorWidth;
+        _minHeightWhenCompressed = JTSScrollIndicator_MinIndicatorHeightWhenCompressed;
+        _minHeightWhenScrolling = JTSScrollIndicator_MinIndicatorHeightWhenScrolling;
+        _rightMargin = JTSScrollIndicator_IndicatorRightMargin;
+        _inherentInsets = JTSScrollIndicator_InherentInset;
+    }
+    return self;
+}
+
+- (void)reloadScrollIndicatorFrame
+{
+    [_indicator setFrame:[JTSScrollIndicator targetRectForScrollView:_indicator.scrollView]];
+}
+
+#pragma mark - Setter
+
+- (void)setWidth:(CGFloat)width
+{
+    _width = width;
+    _indicator.layer.cornerRadius = _width * 0.75;
+    [self reloadScrollIndicatorFrame];
+}
+
+- (void)setMinHeightWhenCompressed:(CGFloat)minHeightWhenCompressed
+{
+    _minHeightWhenCompressed = minHeightWhenCompressed;
+    [self reloadScrollIndicatorFrame];
+}
+
+- (void)setMinHeightWhenScrolling:(CGFloat)minHeightWhenScrolling
+{
+    _minHeightWhenScrolling = minHeightWhenScrolling;
+    [self reloadScrollIndicatorFrame];
+}
+
+- (void)setRightMargin:(CGFloat)rightMargin
+{
+    _rightMargin = rightMargin;
+    [self reloadScrollIndicatorFrame];
+}
+
+- (void)setInherentInsets:(UIEdgeInsets)inherentInsets
+{
+    _inherentInsets = inherentInsets;
+    [self reloadScrollIndicatorFrame];
+}
+
+@end


### PR DESCRIPTION
### Add class named `JTSScrollIndicatorConfig` to make JTSScrollIndicator more customizable.
- The class, JTSScrollIndicatorConfig, has five property to set the style of JTSScrollIndicator.
  - `width`
  - `minHeightWhenCompressed`
  - `minHeightWhenScrolling`
  - `rightMargin`
  - `inherentInsets`
- _How to use_
  - Just call the singleton `JTSScrollIndicatorConfig` object and set the properties.

``` objective-c
    [JTSScrollIndicatorConfig sharedConfig].width = 5.0f;
    [JTSScrollIndicatorConfig sharedConfig].minHeightWhenScrolling = 5.0f;
```
### Hide the default vertical scroll indicator in the `UIScrollView`.
- Because, the default scroll indicator cover the `JTSScrollIndicator`.
